### PR TITLE
feat: optional `npm-shrinkwrap.json` removal

### DIFF
--- a/__tests__/__snapshots__/cli.test.js.snap
+++ b/__tests__/__snapshots__/cli.test.js.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CLI \`--shrinkwrap\` flag 1`] = `
+"✔ Removed:
+npm-shrinkwrap.json"
+`;
+
 exports[`CLI lockfiles found 1`] = `
 "✔ Removed:
 package-lock.json

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -6,21 +6,45 @@ const tempy = require('tempy');
 
 describe('CLI', async () => {
   test('lockfiles found', async () => {
-    expect.assertions(3);
+    expect.assertions(4);
+
     const fixtures = `${__dirname}/fixtures`;
     const tempDir = tempy.directory();
-    copySync(`${fixtures}/_package-lock.json`, `${tempDir}/package-lock.json`);
-    copySync(`${fixtures}/_yarn.lock`, `${tempDir}/yarn.lock`);
+
+    // Copy lockfiles to tempDir
+    const lockfiles = ['package-lock.json', 'yarn.lock', 'npm-shrinkwrap.json'];
+    lockfiles.forEach(lockfile => {
+      copySync(`${fixtures}/_${lockfile}`, `${tempDir}/${lockfile}`);
+    });
 
     const res = await stdout('./cli.js', [tempDir]);
 
     expect(res).toMatchSnapshot();
     expect(existsSync(`${tempDir}/package-lock.json`)).toBe(false);
+    expect(existsSync(`${tempDir}/npm-shrinkwrap.json`)).toBe(true);
     expect(existsSync(`${tempDir}/yarn.lock`)).toBe(false);
+  });
+
+  test('`--shrinkwrap` flag', async () => {
+    expect.assertions(2);
+
+    const fixtures = `${__dirname}/fixtures`;
+    const tempDir = tempy.directory();
+
+    copySync(
+      `${fixtures}/_npm-shrinkwrap.json`,
+      `${tempDir}/npm-shrinkwrap.json`
+    );
+
+    const res = await stdout('./cli.js', [tempDir, '--shrinkwrap']);
+
+    expect(res).toMatchSnapshot();
+    expect(existsSync(`${tempDir}/npm-shrinkwrap.json`)).toBe(false);
   });
 
   test('no lockfile', async () => {
     expect.assertions(3);
+
     const res = await stdout('./cli.js');
 
     expect(res).toMatchSnapshot();

--- a/__tests__/fixtures/_npm-shrinkwrap.json
+++ b/__tests__/fixtures/_npm-shrinkwrap.json
@@ -1,0 +1,5 @@
+{
+  "name": "fixtures",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/cli.js
+++ b/cli.js
@@ -7,24 +7,39 @@ const meow = require('meow');
 
 const removeLockfiles = require('./');
 
-const cli = meow(`
+const cli = meow(
+  `
   Usage
-    $ remove-lockfiles [path]
+    $ remove-lockfiles [path|options]
+
+  Options
+    --shrinkwrap    Include \`npm-shrinkwrap.json\` in removal
 
   Examples
     $ remove-lockfiles
-    $ remove-lockfiles foo
-    $ remove-lockfiles ../bar
-`);
-
-removeLockfiles(cli.input[0]).then(res => {
-  const log = console.log;
-
-  if (res.length === 0) {
-    log(info, blue('No lockfile found'));
+    $ remove-lockfiles ../foo
+    $ remove-lockfiles --shrinkwrap
+    $ remove-lockfiles --shrinkwrap ../foo
+`,
+  {
+    flags: {
+      shrinkwrap: {
+        type: 'boolean',
+      },
+    },
   }
+);
 
-  if (res.length > 0) {
-    log(success, green('Removed:\n') + res.join('\n'));
+removeLockfiles({ cwd: cli.input[0], shrinkwrap: cli.flags.shrinkwrap }).then(
+  res => {
+    const log = console.log;
+
+    if (res.length === 0) {
+      log(info, blue('No lockfile found'));
+    }
+
+    if (res.length > 0) {
+      log(success, green('Removed:\n') + res.join('\n'));
+    }
   }
-});
+);

--- a/index.js
+++ b/index.js
@@ -13,8 +13,10 @@ const remove = (files, cwd) => {
     .then(() => files);
 };
 
-const removeLockfiles = (cwd = process.cwd()) => {
-  const lockfiles = hasLockfile(cwd);
+const removeLockfiles = ({ cwd = process.cwd(), shrinkwrap = false } = {}) => {
+  const lockfiles = shrinkwrap
+    ? hasLockfile(cwd)
+    : hasLockfile(cwd).filter(lockfile => lockfile !== 'npm-shrinkwrap.json');
 
   return lockfiles.length === 0
     ? Promise.resolve(lockfiles)

--- a/readme.md
+++ b/readme.md
@@ -62,12 +62,16 @@ Run the script:
 $ remove-lockfiles --help
 
   Usage
-    $ remove-lockfiles [path]
+    $ remove-lockfiles [path|options]
+
+  Options
+    --shrinkwrap    Include `npm-shrinkwrap.json` in removal
 
   Examples
     $ remove-lockfiles
-    $ remove-lockfiles foo
-    $ remove-lockfiles ../bar
+    $ remove-lockfiles ../foo
+    $ remove-lockfiles --shrinkwrap
+    $ remove-lockfiles --shrinkwrap ../foo
 ```
 
 ## Related


### PR DESCRIPTION
[has-lockfile](https://github.com/luftywiranda13/has-lockfile) v3 detects `npm-shrinkwrap.json`.

We should make removal of `npm-shrinkwrap.json` optional because it's supposed to be published along with the project it's included in.

```sh
$ remove-lockfiles --help

  Usage
    $ remove-lockfiles [path|options]

  Options
    --shrinkwrap    Include `npm-shrinkwrap.json` in removal

  Examples
    $ remove-lockfiles
    $ remove-lockfiles ../foo
    $ remove-lockfiles --shrinkwrap
    $ remove-lockfiles --shrinkwrap ../foo
```